### PR TITLE
Add an objective function to minimise dissapointment

### DIFF
--- a/conference_scheduler/lp_problem/objective_functions.py
+++ b/conference_scheduler/lp_problem/objective_functions.py
@@ -1,0 +1,10 @@
+def capacity_demand_difference(slots, events, X, **kwargs):
+    """
+    A function that minimises the difference between demand for an event and
+    the slot capacity it is scheduled in.
+    """
+    overflow = 0
+    for row, event in enumerate(events):
+        for col, slot in enumerate(slots):
+            overflow += (slot.capacity - event.demand) * X[row, col]
+    return overflow

--- a/conference_scheduler/resources.py
+++ b/conference_scheduler/resources.py
@@ -28,6 +28,7 @@ class Slot(NamedTuple):
     room: Room
     starts_at: datetime
     duration: int
+    capacity: int
 
 
 class Event(NamedTuple):
@@ -37,6 +38,7 @@ class Event(NamedTuple):
     roles: Dict[Role, Person]
     tags: List[str]
     unavailability: List
+    demand: int
 
 
 class Demand(NamedTuple):

--- a/conference_scheduler/scheduler.py
+++ b/conference_scheduler/scheduler.py
@@ -73,7 +73,8 @@ def schedule_violations(schedule, events, slots, sessions, constraints=None):
         solution, events, slots, sessions, constraints)
 
 
-def solution(events, slots, sessions, constraints=None, existing=None):
+def solution(events, slots, sessions, constraints=None, existing=None,
+             objective_function=None):
     shape = Shape(len(events), len(slots))
     problem = pulp.LpProblem()
     X = lp.utils.variables(shape)
@@ -82,6 +83,10 @@ def solution(events, slots, sessions, constraints=None, existing=None):
         events, slots, sessions, X, constraints
     ):
         problem += constraint.condition
+
+    if objective_function is not None:
+        problem += objective_function(events=events, slots=slots,
+                                      sessions=sessions, X=X)
 
     status = problem.solve()
     if status == 1:

--- a/conference_scheduler/tests/conftest.py
+++ b/conference_scheduler/tests/conftest.py
@@ -42,13 +42,20 @@ def rooms(event_types):
 @pytest.fixture(scope="module")
 def slots(rooms):
     return (
-        Slot(room=rooms[0], starts_at='15-Sep-2016 09:30', duration=30),
-        Slot(room=rooms[0], starts_at='15-Sep-2016 10:00', duration=30),
-        Slot(room=rooms[0], starts_at='15-Sep-2016 11:30', duration=30),
-        Slot(room=rooms[0], starts_at='15-Sep-2016 12:00', duration=30),
-        Slot(room=rooms[0], starts_at='15-Sep-2016 12:30', duration=30),
-        Slot(room=rooms[1], starts_at='15-Sep-2016 09:30', duration=90),
-        Slot(room=rooms[1], starts_at='15-Sep-2016 11:30', duration=90)
+        Slot(room=rooms[0], starts_at='15-Sep-2016 09:30', duration=30,
+             capacity=50),
+        Slot(room=rooms[0], starts_at='15-Sep-2016 10:00', duration=30,
+             capacity=50),
+        Slot(room=rooms[0], starts_at='15-Sep-2016 11:30', duration=30,
+             capacity=50),
+        Slot(room=rooms[0], starts_at='15-Sep-2016 12:00', duration=30,
+             capacity=10),
+        Slot(room=rooms[0], starts_at='15-Sep-2016 12:30', duration=30,
+             capacity=50),
+        Slot(room=rooms[1], starts_at='15-Sep-2016 09:30', duration=90,
+             capacity=200),
+        Slot(room=rooms[1], starts_at='15-Sep-2016 11:30', duration=90,
+             capacity=200)
     )
 
 
@@ -79,21 +86,24 @@ def events(event_types, roles, people, slots):
         duration=30,
         roles={roles['speaker']: people['alice']},
         tags=['community'],
-        unavailability=[slots[0], slots[1]])
+        unavailability=[slots[0], slots[1]],
+        demand=30)
     event2 = Event(
         name='Talk 2',
         event_type=event_types['talk'],
         duration=30,
         roles={roles['speaker']: people['bob']},
         tags=['community', 'documentation'],
-        unavailability=[slots[2], slots[3], event1])
+        unavailability=[slots[2], slots[3], event1],
+        demand=500)
     event3 = Event(
         name='Workshop 1',
         event_type=event_types['workshop'],
         duration=60,
         roles={roles['leader']: people['charlie']},
         tags=['documentation'],
-        unavailability=[])
+        unavailability=[],
+        demand=20)
     return (event1, event2, event3)
 
 

--- a/conference_scheduler/tests/lp_problem/test_objective_functions.py
+++ b/conference_scheduler/tests/lp_problem/test_objective_functions.py
@@ -1,0 +1,25 @@
+import numpy as np
+from conference_scheduler.lp_problem import objective_functions as of
+
+
+def test_capacity_demand_difference(slots, events, X):
+    function = of.capacity_demand_difference(slots, events, X)
+    assert len(function) == 21
+
+
+def test_capacity_demand_difference_with_examples(slots, events):
+    X = np.array([
+        [1, 0, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 1, 0, 0],
+        [0, 1, 0, 0, 0, 0, 0]
+    ])
+    overflow = of.capacity_demand_difference(slots, events, X)
+    assert overflow == -400
+
+    X = np.array([
+        [1, 0, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 1, 0, 0],
+        [0, 0, 0, 1, 0, 0, 0]
+    ])
+    overflow = of.capacity_demand_difference(slots, events, X)
+    assert overflow == -440

--- a/conference_scheduler/tests/test_scheduler.py
+++ b/conference_scheduler/tests/test_scheduler.py
@@ -2,6 +2,7 @@ import numpy as np
 from collections import Counter
 from conference_scheduler import scheduler
 from conference_scheduler.resources import ScheduledItem
+from conference_scheduler.lp_problem import objective_functions as of
 
 
 def test_valid_solution_has_no_violations(
@@ -147,3 +148,10 @@ def test_slots_scheduled_once_only(solution):
 def test_events_scheduled_once_only(solution):
     for event, count in Counter(item[0] for item in solution).items():
         assert count == 1
+
+
+def test_optimal_schedule(slots, events, sessions):
+    solution = scheduler.solution(
+            events=events, slots=slots, sessions=sessions,
+            objective_function=of.capacity_demand_difference)
+    assert list(solution) == [(0, 3), (1, 4), (2, 0)]


### PR DESCRIPTION
Closes #3 

- Have added capacity and demand to slots and events. A slot might be constrained by more than the room: a speaker/workshop might only cater for 5 people but the room handles 10 for example. I haven't removed the capacity from rooms as that might still be useful elsewhere (this is all similar to our discussions about unavailability etc...)
- Have added the ability to pass an objective function to the `scheduler.solution`. I've done this by allowing the objective function to accept extra `kwargs` and only use the ones it needs.
- Have added a test for the objective function being called by the scheduled but I wasn't too sure this is how you wanted to do it so let me know :) 