### PR TITLE
Ensure we include the lp_scheduler subpackage

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 # Read in the version number
 __version__ = None  # This makes linters happy
@@ -8,9 +8,7 @@ with open('conference_scheduler/version.py', 'r') as f:
 setup(
     name='conference-scheduler',
     version=__version__,
-    packages=[
-        'conference_scheduler',
-    ],
+    packages=find_packages(),
     url='https://github.com/PyconUK/ConferenceScheduler',
     license='MIT',
     author='Owen Campbell, Vince Knight',


### PR DESCRIPTION
When hard-coding the `packages` variable, we only pick up the Python files in the root of `conference_scheduler`.  This ensures we traverse subdirectories and pick up `lp_scheduler`.

Resolves #51.

Testing: run `python setup.py install` in a fresh virtualenv in the repo root, then run `python -c 'from conference_scheduler import scheduler` from a different directory.

I’d have no objections to switching to a `<root>/src/conference_scheduler` layout, although I confess I’ve been doing it for so long I’ve forgotten why I originally decided to do so!