### PR TITLE
Set default values for `tags` and `availability`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 #########
 
+v1.3.0 (tbc)
+------------
+*  Enhancement: the ``tags`` and ``availability`` arguments to ``Event`` are
+   optional, and default to an empty list.
+   `#74 <https://github.com/PyconUK/ConferenceScheduler/pull/74>`_
 
 v1.2.0 (2017-05-09)
 -------------------

--- a/docs/howtos/mathematical_representation.rst
+++ b/docs/howtos/mathematical_representation.rst
@@ -10,8 +10,8 @@ Let us schedule a simple conference as described in :ref:`tutorial`::
 
     >>> slots  = [Slot(venue='Big', starts_at='15-Sep-2016 09:30', duration=30, session="A", capacity=200),
     ...           Slot(venue='Big', starts_at='15-Sep-2016 10:00', duration=30, session="A", capacity=200)]
-    >>> events = [Event(name='Talk 1', duration=30, tags=[], unavailability=[], demand=50),
-    ...           Event(name='Talk 2', duration=30, tags=[], unavailability=[], demand=130)]
+    >>> events = [Event(name='Talk 1', duration=30, demand=50),
+    ...           Event(name='Talk 2', duration=30, demand=130)]
 
     >>> schedule = scheduler.schedule(events, slots)
 

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -332,12 +332,12 @@ We will need 6 chairpersons for these slots and we will use events as chairs. In
 practice, all chairing will be taken care of by 3 people, with each person
 chairing 2 sessions::
 
-    >>> events = [Event(name='Chair A-1', duration=60, tags=[], unavailability=[], demand=0),
-    ...           Event(name='Chair A-2', duration=60, tags=[], unavailability=[], demand=0),
-    ...           Event(name='Chair B-1', duration=60, tags=[], unavailability=[], demand=0),
-    ...           Event(name='Chair B-2', duration=60, tags=[], unavailability=[], demand=0),
-    ...           Event(name='Chair C-1', duration=60, tags=[], unavailability=[], demand=0),
-    ...           Event(name='Chair D-2', duration=60, tags=[], unavailability=[], demand=0)]
+    >>> events = [Event(name='Chair A-1', duration=60, demand=0),
+    ...           Event(name='Chair A-2', duration=60, demand=0),
+    ...           Event(name='Chair B-1', duration=60, demand=0),
+    ...           Event(name='Chair B-2', duration=60, demand=0),
+    ...           Event(name='Chair C-1', duration=60, demand=0),
+    ...           Event(name='Chair D-2', duration=60, demand=0)]
 
 
 As you can see, we have set all unavailabilities to be empty however

--- a/src/conference_scheduler/resources.py
+++ b/src/conference_scheduler/resources.py
@@ -1,4 +1,4 @@
-from typing import NamedTuple, Sequence, Dict, Iterable, List
+from typing import NamedTuple
 from datetime import datetime
 
 

--- a/src/conference_scheduler/resources.py
+++ b/src/conference_scheduler/resources.py
@@ -10,12 +10,26 @@ class Slot(NamedTuple):
     session: str
 
 
-class Event(NamedTuple):
+class BaseEvent(NamedTuple):
     name: str
     duration: int
     demand: int
-    tags: List[str] = []
-    unavailability: List = []
+    tags: List[str]
+    unavailability: List
+
+
+class Event(BaseEvent):
+
+    __slots__ = ()
+
+    def __new__(cls, name, duration, demand, tags=None, unavailability=None):
+        if tags is None:
+            tags = []
+        if unavailability is None:
+            unavailability = []
+        return super().__new__(
+            cls, name, duration, demand, tags, unavailability
+        )
 
 
 class ScheduledItem(NamedTuple):

--- a/src/conference_scheduler/resources.py
+++ b/src/conference_scheduler/resources.py
@@ -10,26 +10,43 @@ class Slot(NamedTuple):
     session: str
 
 
-class BaseEvent(NamedTuple):
-    name: str
-    duration: int
-    demand: int
-    tags: List[str]
-    unavailability: List
+class Event:
 
-
-class Event(BaseEvent):
-
-    __slots__ = ()
-
-    def __new__(cls, name, duration, demand, tags=None, unavailability=None):
+    def __init__(self, name, duration, demand, tags=None, unavailability=None):
+        self.name = name
+        self.duration = duration
+        self.demand = demand
         if tags is None:
             tags = []
+        self.tags = tags
         if unavailability is None:
             unavailability = []
-        return super().__new__(
-            cls, name, duration, demand, tags, unavailability
+        self.unavailability = unavailability
+
+    def __repr__(self):
+        return (
+            f'{type(self).__name__}('
+            f'name={self.name!r}, duration={self.duration!r}, '
+            f'demand={self.demand!r}, tags={self.tags!r}, '
+            f'unavailability={self.unavailability!r})'
         )
+
+    def __eq__(self, other):
+        if not isinstance(other, Event):
+            return False
+        return (
+            self.name == other.name and
+            self.duration == other.duration and
+            self.demand == other.demand and
+            self.tags == other.tags and
+            self.unavailability == other.unavailability
+        )
+
+    def __ne__(self, other):
+        return not (self == other)
+
+    def __hash__(self):
+        return hash(repr(self))
 
 
 class ScheduledItem(NamedTuple):

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -33,3 +33,8 @@ def test_optional_args_are_safely_mutable():
     # polluted the default arguments.
     f = Event(name='another example', duration=30, demand=50)
     assert f.tags == []
+
+
+def test_event_is_hashable():
+    e = Event(name='example', duration=60, demand=100)
+    events = set([e])

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,0 +1,35 @@
+from conference_scheduler.resources import Event
+
+
+def test_can_construct_event():
+    e = Event(
+        name='example',
+        duration=60,
+        demand=100,
+        tags=['beginner', 'python'],
+        unavailability=[]
+    )
+    assert isinstance(e, Event)
+    assert e.name == 'example'
+    assert e.tags == ['beginner', 'python']
+    assert e.unavailability == []
+
+
+def test_optional_args_to_event_are_defaulted():
+    e = Event(name='example', duration=60, demand=100)
+    assert e.tags == []
+    assert e.unavailability == []
+
+
+def test_optional_args_are_safely_mutable():
+    # Construct an instance of `Event` with the optional arguments,
+    # omitted, then assign it a tag
+    e = Event(name='example', duration=60, demand=100)
+    assert e.tags == []
+    e.tags.append('intermediate')
+    assert e.tags == ['intermediate']
+
+    # Now create a second instance of `Event`, and check we haven't
+    # polluted the default arguments.
+    f = Event(name='another example', duration=30, demand=50)
+    assert f.tags == []


### PR DESCRIPTION
Setting default arguments on a namedtuple is moderately fiddly, but this seems to work. Prints in the same way as the original, and has no effect on occupancy:

```pycon
>>> from conference_scheduler.resources import BaseEvent, Event
>>> e = BaseEvent(name='example', duration=60, demand=100, tags=[], unavailability=[])
>>> f = Event(name='example', duration=60, demand=100)
>>> f
Event(name='example', duration=60, demand=100, tags=[], unavailability=[])
>>> assert e.__sizeof__() == f.__sizeof__()
```

Resolves #73.