### PR TITLE
Use integers instead of floats for arrays returned from scheduler.array

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,11 @@ Changelog
 Unreleased
 ----------
 
+*  Enhancement: ``scheduler.array``, ``scheduler.schedule_to_array`` and
+   ``scheduler.solution_to_array`` now return arrays of integers, not
+   arrays of floats.
+   `#94 <https://github.com/PyconUK/ConferenceScheduler/pull/94>`_
+
 v2.0.0 (2017-05-12)
 -------------------
 *  Incompatibility: ``Event.tags`` and ``Event.unavailability`` are now immutable

--- a/docs/howto/obtain_mathematical_representation.rst
+++ b/docs/howto/obtain_mathematical_representation.rst
@@ -28,8 +28,8 @@ function::
 
     >>> array = scheduler.schedule_to_array(schedule, events=events, slots=slots)
     >>> array
-    array([[ 1.,  0.],
-           [ 0.,  1.]])
+    array([[1, 0],
+           [0, 1]])
 
 We can also return from a mathematical array to the schedule using the
 :code:`scheduler.array_to_schedule` function::

--- a/docs/howto/obtain_mathematical_representation.rst
+++ b/docs/howto/obtain_mathematical_representation.rst
@@ -29,7 +29,7 @@ function::
     >>> array = scheduler.schedule_to_array(schedule, events=events, slots=slots)
     >>> array
     array([[1, 0],
-           [0, 1]])
+           [0, 1]], dtype=int8)
 
 We can also return from a mathematical array to the schedule using the
 :code:`scheduler.array_to_schedule` function::

--- a/src/conference_scheduler/scheduler.py
+++ b/src/conference_scheduler/scheduler.py
@@ -180,7 +180,7 @@ def solution_to_array(solution, events, slots):
          [0, 0, 0, 0, 1, 0, 0],
          [0, 0, 0, 0, 0, 1, 0]]
     """
-    array = np.zeros((len(events), len(slots)), dtype=np.int64)
+    array = np.zeros((len(events), len(slots)), dtype=np.int8)
     for item in solution:
         array[item[0], item[1]] = 1
     return array
@@ -231,7 +231,7 @@ def schedule_to_array(schedule, events, slots):
         number of slots. Xij is 1 if event i is scheduled in slot j and
         zero otherwise
     """
-    array = np.zeros((len(events), len(slots)), dtype=np.int64)
+    array = np.zeros((len(events), len(slots)), dtype=np.int8)
     for item in schedule:
         array[events.index(item.event), slots.index(item.slot)] = 1
     return array

--- a/src/conference_scheduler/scheduler.py
+++ b/src/conference_scheduler/scheduler.py
@@ -180,7 +180,7 @@ def solution_to_array(solution, events, slots):
          [0, 0, 0, 0, 1, 0, 0],
          [0, 0, 0, 0, 0, 1, 0]]
     """
-    array = np.zeros((len(events), len(slots)))
+    array = np.zeros((len(events), len(slots)), dtype=np.int)
     for item in solution:
         array[item[0], item[1]] = 1
     return array
@@ -231,7 +231,7 @@ def schedule_to_array(schedule, events, slots):
         number of slots. Xij is 1 if event i is scheduled in slot j and
         zero otherwise
     """
-    array = np.zeros((len(events), len(slots)))
+    array = np.zeros((len(events), len(slots)), dtype=np.int)
     for item in schedule:
         array[events.index(item.event), slots.index(item.slot)] = 1
     return array

--- a/src/conference_scheduler/scheduler.py
+++ b/src/conference_scheduler/scheduler.py
@@ -180,7 +180,7 @@ def solution_to_array(solution, events, slots):
          [0, 0, 0, 0, 1, 0, 0],
          [0, 0, 0, 0, 0, 1, 0]]
     """
-    array = np.zeros((len(events), len(slots)), dtype=np.int)
+    array = np.zeros((len(events), len(slots)), dtype=np.int64)
     for item in solution:
         array[item[0], item[1]] = 1
     return array
@@ -231,7 +231,7 @@ def schedule_to_array(schedule, events, slots):
         number of slots. Xij is 1 if event i is scheduled in slot j and
         zero otherwise
     """
-    array = np.zeros((len(events), len(slots)), dtype=np.int)
+    array = np.zeros((len(events), len(slots)), dtype=np.int64)
     for item in schedule:
         array[events.index(item.event), slots.index(item.slot)] = 1
     return array

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -108,6 +108,10 @@ def test_array_nonzero(array):
     assert len(nonzero) == 3
 
 
+def test_array_contains_ints(array):
+    assert all([isinstance(x, np.int64) for x in array.flat])
+
+
 # Schedule form
 # Similar to array form, there is less testsing here since it simply converts
 # the output of scheduler.solution to schedule form
@@ -127,6 +131,7 @@ def test_schedule_has_all_events(schedule, events):
 def test_solution_to_array(valid_solution, valid_array, events, slots):
     array = scheduler.solution_to_array(valid_solution, events, slots)
     assert np.array_equal(array, valid_array)
+    assert all([isinstance(x, np.int64) for x in array.flat])
 
 
 def test_solution_to_schedule(valid_solution, valid_schedule, events, slots):
@@ -138,6 +143,7 @@ def test_solution_to_schedule(valid_solution, valid_schedule, events, slots):
 def test_schedule_to_array(valid_schedule, valid_array, events, slots):
     array = scheduler.schedule_to_array(valid_schedule, events, slots)
     assert np.array_equal(array, valid_array)
+    assert all([isinstance(x, np.int64) for x in array.flat])
 
 
 def test_array_to_schedule(valid_schedule, valid_array, events, slots):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -109,7 +109,7 @@ def test_array_nonzero(array):
 
 
 def test_array_contains_ints(array):
-    assert all([isinstance(x, np.int64) for x in array.flat])
+    assert all([isinstance(x, np.int8) for x in array.flat])
 
 
 # Schedule form
@@ -131,7 +131,7 @@ def test_schedule_has_all_events(schedule, events):
 def test_solution_to_array(valid_solution, valid_array, events, slots):
     array = scheduler.solution_to_array(valid_solution, events, slots)
     assert np.array_equal(array, valid_array)
-    assert all([isinstance(x, np.int64) for x in array.flat])
+    assert all([isinstance(x, np.int8) for x in array.flat])
 
 
 def test_solution_to_schedule(valid_solution, valid_schedule, events, slots):
@@ -143,7 +143,7 @@ def test_solution_to_schedule(valid_solution, valid_schedule, events, slots):
 def test_schedule_to_array(valid_schedule, valid_array, events, slots):
     array = scheduler.schedule_to_array(valid_schedule, events, slots)
     assert np.array_equal(array, valid_array)
-    assert all([isinstance(x, np.int64) for x in array.flat])
+    assert all([isinstance(x, np.int8) for x in array.flat])
 
 
 def test_array_to_schedule(valid_schedule, valid_array, events, slots):


### PR DESCRIPTION
Resolves #91.